### PR TITLE
removing extraneous spaces after colons that confuse some editors (no…

### DIFF
--- a/TemplateMerges/ap-sbom-v1.0-wd01.md
+++ b/TemplateMerges/ap-sbom-v1.0-wd01.md
@@ -174,7 +174,7 @@ text.
 | **content** | Message body as specified by content_type and msg_type. |
 
 Here is a reference to the table caption:
-Please see [Table 1-5 or other meaningful label](#table-1-5-see-reference-label-construction) 
+Please see [Table 1-5 or other meaningful label](#table-1-5-see-reference-label-construction)
 
 
 ### 1.3.3 Lists
@@ -243,7 +243,7 @@ Note the actual backticks will not appear in the HTML format. If it's necessary 
 }
 ```
 
-Text to be highlighted as code can also be surrounded by a single "backtick" character: 
+Text to be highlighted as code can also be surrounded by a single "backtick" character:
 `code text`
 
 ## 1.4 Page Breaks


### PR DESCRIPTION
the spec editor uses atom for his editor and it is set up to remove spaces following colon's. This doesn't affect anything but it does make editor's life easier.