### PR TITLE
Simplify device integration

### DIFF
--- a/oc2ap-sbom-v0.5.jidl
+++ b/oc2ap-sbom-v0.5.jidl
@@ -1,87 +1,71 @@
        title: "OpenC2 SBOM Retrieval Actuator Profile"
      package: "http://docs.oasis-open.org/openc2/ns/ap-sbom/v2.0"
   namespaces: {"ls": "http://docs.oasis-open.org/openc2/ns/types/v2.0"}
-     exports: ["AP-Target", "AP-Specifiers", "AP-Results"]
+     exports: ["Action", "Target", "Args", "Results", "Pairs"]
 
 Action = Enumerated
    3 query
 
-Target = Enumerated
-   9 features
-1034 sbom
+Target = Choice                                    // Profile-defined targets
+   1 sbom             SBOM-Specifiers              // Return specific SBOM  ????? how change this?
+   2 sbom_list        SBOM-List                    // Return list of SBOMs ID and metadata
 
-Args = Enumerated
-   1 start_time
-   2 stop_time
-   3 duration
-   4 response_requested
+Args = Map                                         // Profile-defined command arguments
 
-Actuator = Enumerated
-1034 sbom
+Results = Map{1..*}                                // Profile-defined response results
+   1 sboms            ArrayOf(SBOM-Info)           // List of all SBOMs matching query criteria
 
-Results = Enumerated
-   1 versions
-   2 profiles
-   3 pairs
-   4 rate_limit
-1034 sbom
+Pairs = Map
+   3 query            ArrayOf(Query-Targets) unique
 
-Pairs = Enumerated
-   3 query: features, /sboms, /sbom_list
+Query-Targets = Enumerated
+   1 sboms
+   2 sbom_list
 
-AP-Target = Choice                                // Profile-defined targets
-   1 sbom            SBOM-Specifiers             // Return specific SBOM  ????? how change this?
-   2 sbom_list        SBOM-List                   // Return list of SBOMs ID and metadata
-
-AP-Specifiers = Map                               // Profile-defined actuator specifiers
-
-AP-Results = Map{1..*}                            // Profile-defined response results
-   1 sboms            ArrayOf(SBOM-Info)          // List of all SBOMs matching query criteria
-
-SBOM-Specifiers = Map                             // If none specified, return IDs for all SBOMs
+SBOM-Specifiers = Map                              // If none specified, return IDs for all SBOMs
    1 type             ArrayOf(Enum[SBOM-Content]) unique optional // SBOM type
    2 format           ArrayOf(DataFormat) unique optional // Data format
    3 info             ArrayOf(Info){1..*} unique optional // Type of SBOM info to return
 
 SBOM-List = Map
-   1 sids             ls:URI [1..*]               // SBOM IDs to return
-   2 info             ArrayOf(Info){1..*} unique  // Type of SBOM info to return
+   1 sids             ls:URI [1..*]                // SBOM IDs to return
+   2 info             ArrayOf(Info){1..*} unique         // Type of SBOM info to return
+
+Info = Enumerated                                  // SBOM-Info fields to return
+   1 summary                                       // NTIA Minimumum Elements of an SBOM
+   2 content                                       // SBOM structured data
+   3 blob                                          // Uninterpreted SBOM bytes
 
 SBOM-Info = Map
    1 type             Enumerated(Enum[SBOM-Content]) // SBOM type (name of standard)
-   2 format           DataFormat                  // Data (serialization) format
-   3 sid              ls:URI                      // Unique identifier or locator of the SBOM
-   4 summary          SBOM-Elements optional      // NTIA Minimumum Elements of an SBOM
-   5 content          SBOM-Content optional       // SBOM structured data
-   6 blob             Binary optional             // Uninterpreted SBOM bytes
-
-Info = Enumerated                                 // SBOM-Info fields to return
-   1 summary                                      // NTIA Minimumum Elements of an SBOM
-   2 content                                      // SBOM structured data
-   3 blob                                         // Uninterpreted SBOM bytes
+   2 format           DataFormat                   // Data (serialization) format
+   3 sid              ls:URI                       // Unique identifier or locator of the SBOM
+   4 summary          SBOM-Elements optional       // NTIA Minimumum Elements of an SBOM
+   5 content          SBOM-Content optional        // SBOM structured data
+   6 blob             Binary optional              // Uninterpreted SBOM bytes
 
 SBOM-Elements = Record
-   1 supplier         String [1..*]               // Name of entity that creates, defines, and identifies components
-   2 component        String [1..*]               // Designation(s) assigned to a unit of software defined by the original supplier
-   3 version          String                      // Identifier used by supplier to specify a change from a previously identified version
-   4 component_ids    String [1..*]               // Other identifiers used to identify a component, or serve as a look-yp key
-   5 dependencies     String [1..*]               // Upstream component(s)
-   6 author           String                      // Name of the entity that creates SBOM data for this component
-   7 timestamp        DateTime                    // Record of the date and time of the SBOM data assembly
+   1 supplier         String [1..*]                // Name of entity that creates, defines, and identifies components
+   2 component        String [1..*]                // Designation(s) assigned to a unit of software defined by the original supplier
+   3 version          String                       // Identifier used by supplier to specify a change from a previously identified version
+   4 component_ids    String [1..*]                // Other identifiers used to identify a component, or serve as a look-yp key
+   5 dependencies     String [1..*]                // Upstream component(s)
+   6 author           String                       // Name of the entity that creates SBOM data for this component
+   7 timestamp        DateTime                     // Record of the date and time of the SBOM data assembly
 
 SBOM-Content = Choice
-   1 cyclonedx        String                      // Placeholder for CycloneDX data model
-   2 spdx2            String                      // Placeholder for SPDX v2.x data model
-   3 spdx3            String                      // Placeholder for SPDX v3 data model
+   1 cyclonedx        String                       // Placeholder for CycloneDX data model
+   2 spdx2            String                       // Placeholder for SPDX v2.x data model
+   3 spdx3            String                       // Placeholder for SPDX v3 data model
 
-DataFormat = Enumerated                           // Serialization Data Formats
-   1 ttv                                          // Text Tag-Value
-   2 json                                         // JSON verbose
-   3 json-m                                       // JSON concise/minimized
-   4 json-ld                                      // JSON linked data
-   5 cbor                                         // CBOR binary
-   6 protobuf                                     // Protocol Buffers binary
-   7 xml                                          // XML
-   8 ss-csv                                       // Spreadsheet comma separated values
+DataFormat = Enumerated                            // Serialization Data Formats
+   1 ttv                                           // Text Tag-Value
+   2 json                                          // JSON verbose
+   3 json-m                                        // JSON concise/minimized
+   4 json-ld                                       // JSON linked data
+   5 cbor                                          // CBOR binary
+   6 protobuf                                      // Protocol Buffers binary
+   7 xml                                           // XML
+   8 ss-csv                                        // Spreadsheet comma separated values
 
 DateTime = Integer{0..*}


### PR DESCRIPTION
Apply new structure to all APs

1) Rename AP-Target, AP-Args, AP-Results to just Target, Args, Results
2) Add new Pairs type to enable per-AP query pairs result
3) Delete AP-Specifiers - v2 "profile" field replaces "actuator" and doesn't have specifiers